### PR TITLE
feat: allow defining additional server mappings in setup

### DIFF
--- a/lua/mason-lspconfig/settings.lua
+++ b/lua/mason-lspconfig/settings.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+---@class MasonLspconfigServerSettings
+---@field server string the lspconfig server name
+---@field public package string the Mason package name
+---@field filetypes string[] the filetypes that the server applies to
+---@field config? table|fun(): table extensions to the default language server configuration
+
 ---@class MasonLspconfigSettings
 local DEFAULT_SETTINGS = {
     -- A list of servers to automatically install if they're not already installed. Example: { "rust_analyzer@nightly", "lua_ls" }
@@ -20,6 +26,8 @@ local DEFAULT_SETTINGS = {
     -- See `:h mason-lspconfig.setup_handlers()`
     ---@type table<string, fun(server_name: string)>?
     handlers = nil,
+    ---@type table<string, MasonLspconfigServerSettings>?
+    servers = nil,
 }
 
 M._DEFAULT_SETTINGS = DEFAULT_SETTINGS


### PR DESCRIPTION
This starts exploring the possibility of allowing the users to extend the language server mappings from the `setup()` function. This can be very useful in the situation where the user is using their own Mason registries and want to add support for their packages to be connected to language servers without necessarily adding it to the core repository here.

Here is an example of the usage of the current implementation in this PR:

```lua
require("mason-lspconfig").setup {
  servers = {
    {
      server = "nextflow_ls", -- required lspconfig sever name (string)
      package = "nextflow-language-server", -- required package name in Mason (string)
      filetypes = { "nextflow" }, -- required filetypes that apply (array of strings)
      config = { -- optional default configuration changes (table or a function that returns a table)
        cmd = { "nextflow-language-server" },
      },
    },
  },
},
```

I wanted to open this just to see if this is something worth exploring more. If so then I can add documentation and tests. Right now the "hackiest" part is more in the addition of "fake" modules for the additional sever configuration extensions. This is mainly just to play nicely with the current structure of the repository.

Let me know what you think!