### PR TITLE
feat: add fountain-lsp-server support

### DIFF
--- a/doc/mason-lspconfig-mapping.txt
+++ b/doc/mason-lspconfig-mapping.txt
@@ -67,6 +67,7 @@ fennel-ls                                 fennel_ls
 flux-lsp                                  flux_lsp
 foam-language-server                      foam_ls
 fortls                                    fortls
+fountain-lsp-server                       fountain-lsp-server
 fsautocomplete                            fsautocomplete
 ginko_ls                                  ginko_ls
 gitlab-ci-ls                              gitlab_ci_ls

--- a/doc/server-mapping.md
+++ b/doc/server-mapping.md
@@ -64,6 +64,7 @@
 | [flux_lsp](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#flux_lsp) | [flux-lsp](https://mason-registry.dev/registry/list#flux-lsp) |
 | [foam_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#foam_ls) | [foam-language-server](https://mason-registry.dev/registry/list#foam-language-server) |
 | [fortls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#fortls) | [fortls](https://mason-registry.dev/registry/list#fortls) |
+| [fountain-lsp-server](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#fountain-lsp-server) | [fountain-lsp-server](https://mason-registry.dev/registry/list#fountain-lsp-server) |
 | [fsautocomplete](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#fsautocomplete) | [fsautocomplete](https://mason-registry.dev/registry/list#fsautocomplete) |
 | [ginko_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#ginko_ls) | [ginko_ls](https://mason-registry.dev/registry/list#ginko_ls) |
 | [gitlab_ci_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#gitlab_ci_ls) | [gitlab-ci-ls](https://mason-registry.dev/registry/list#gitlab-ci-ls) |

--- a/lua/mason-lspconfig/mappings/filetype.lua
+++ b/lua/mason-lspconfig/mappings/filetype.lua
@@ -247,4 +247,4 @@ return {
   yml = { "spectral" },
   zig = { "zls" },
   zir = { "zls" }
-}
+}    fountain = { "fountain-lsp-server" },

--- a/lua/mason-lspconfig/mappings/server.lua
+++ b/lua/mason-lspconfig/mappings/server.lua
@@ -67,6 +67,7 @@ M.lspconfig_to_package = {
     ["flux_lsp"] = "flux-lsp",
     ["foam_ls"] = "foam-language-server",
     ["fortls"] = "fortls",
+    ["fountain-lsp-server"] = "fountain-lsp-server",
     ["fsautocomplete"] = "fsautocomplete",
     ["gitlab_ci_ls"] = "gitlab-ci-ls",
     ["ginko_ls"] = "ginko_ls",


### PR DESCRIPTION
adds support for [fountain-lsp-server](https://github.com/oparaskos/fountain-lsp-server)
it depends on the package from the [mason registry](https://github.com/mason-org/mason-registry/pull/9584) or can be built from source