### PR TITLE
fix: rename omnisharp cmd executable

### DIFF
--- a/lua/mason-lspconfig/lsp/omnisharp.lua
+++ b/lua/mason-lspconfig/lsp/omnisharp.lua
@@ -1,6 +1,6 @@
 return {
     cmd = {
-        "omnisharp",
+        "OmniSharp",
         "-z", -- https://github.com/OmniSharp/omnisharp-vscode/pull/4300
         "--hostPID",
         tostring(vim.fn.getpid()),


### PR DESCRIPTION
It looks like the executable is not being called correctly.
I'm not very familiar with the Mason codebase, so it's possible the best approach is to update the install process to always reference the executable in lowercase (as described here: mason-org/mason.nvim/issues/1941) - or any other way...

Fixes mason-org/mason.nvim#1941

happy to receive any feedback