### PR TITLE
perf: cache the result of get_all_package_specs (Fixes #594)

### DIFF
--- a/lua/mason-lspconfig/mappings.lua
+++ b/lua/mason-lspconfig/mappings.lua
@@ -3,10 +3,15 @@ local registry = require "mason-registry"
 
 local M = {}
 
+local package_specs_cache = nil
+
 function M.get_mason_map()
     ---@type table<string, string>
     local package_to_lspconfig = {}
-    for _, pkg_spec in ipairs(registry.get_all_package_specs()) do
+    if package_specs_cache == nil then
+        package_specs_cache = registry.get_all_package_specs()
+    end
+    for _, pkg_spec in ipairs(package_specs_cache) do
         local lspconfig = vim.tbl_get(pkg_spec, "neovim", "lspconfig")
         if lspconfig then
             package_to_lspconfig[pkg_spec.name] = lspconfig


### PR DESCRIPTION
This is a pull request to fix #594 

I decided to fix the problem by caching the result on the caller side of `get_all_package_specs` to not change any behavior in mason.nvim. If it would be better to cache the result in `mason.nvim` then I can open the equivalent version of this pr in mason.nvim