### PR TITLE
fix: append PowerShellEditorServices to bundle_path

### DIFF
--- a/lua/mason-lspconfig/lsp/powershell_es.lua
+++ b/lua/mason-lspconfig/lsp/powershell_es.lua
@@ -1,3 +1,3 @@
 return {
-    bundle_path = vim.fn.expand "$MASON/packages/powershell-editor-services",
+    bundle_path = vim.fn.expand "$MASON/packages/powershell-editor-services/PowerShellEditorServices",
 }


### PR DESCRIPTION
The bundled Start-EditorServices.ps1 lives under a nested PowerShellEditorServices/ directory inside the mason package, but bundle_path pointed at the package root, causing pwsh to fail resolving the script path:

```log
The term 'C:\Users\warbacon\AppData\Local\nvim-data\mason\packages\powershell-editor-services/Start-EditorServices.ps1' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

Verified the nested directory against the actual installed package contents and appended it to bundle_path.

Tested on Windows 11 with powershell-editor-services v4.7.0.

Fixes #694.